### PR TITLE
fix: output subprocess logs only when the `dumpio` option is enabled

### DIFF
--- a/src/deno/BrowserRunner.ts
+++ b/src/deno/BrowserRunner.ts
@@ -55,7 +55,7 @@ export class BrowserRunner {
   }
 
   start(options: LaunchOptions): void {
-    const { env } = options;
+    const { env, dumpio } = options;
     assert(!this.proc, "This process has previously been started.");
     debugLauncher(
       `Calling ${this._executablePath} ${this._processArguments.join(" ")}`
@@ -72,7 +72,7 @@ export class BrowserRunner {
       this._closed = true;
       try {
         if (this.proc) {
-          if (!status.success) {
+          if (!status.success && dumpio) {
             await Deno.copy(this.proc.stdout!, Deno.stdout);
             await Deno.copy(this.proc.stderr!, Deno.stderr);
           }

--- a/src/deno/LaunchOptions.ts
+++ b/src/deno/LaunchOptions.ts
@@ -34,4 +34,5 @@ export interface LaunchOptions {
   ignoreDefaultArgs?: boolean | string[];
   timeout?: number;
   env?: Record<string, string>;
+  dumpio?: boolean;
 }

--- a/src/deno/Launcher.ts
+++ b/src/deno/Launcher.ts
@@ -59,6 +59,7 @@ class ChromeLauncher implements ProductLauncher {
       defaultViewport = { width: 800, height: 600 },
       slowMo = 0,
       timeout = 30000,
+      dumpio = false,
     } = options;
 
     const profilePath = pathJoin(
@@ -106,6 +107,7 @@ class ChromeLauncher implements ProductLauncher {
     );
     runner.start({
       env,
+      dumpio,
     });
 
     try {


### PR DESCRIPTION
This PR fixes #8.