### PR TITLE
Fix #13: Make Chromium Helpers executable on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         deno: ["v1.x", "nightly"]
-        os: [windows-latest, ubuntu-latest] # Can't run on macOS because headless isn't working there.
+        os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This PR fixes #13, a bug in which Chromium does not start by default on macOS due to a permissions error.