### PR TITLE
Fix concatenation of PDF streams (fixes #27)

### DIFF
--- a/vendor/puppeteer-core/puppeteer/common/helper.js
+++ b/vendor/puppeteer-core/puppeteer/common/helper.js
@@ -266,7 +266,7 @@ async function readProtocolStream(client, handle, path) {
   await client.send("IO.close", { handle });
   let resultArr = null;
   try {
-    resultArr = concatUint8Array(arrs);
+    resultArr = concatUint8Array(...arrs);
   } finally {
     return resultArr;
   }


### PR DESCRIPTION
Previously, the method returned `Uint8Array(2) [ 0, 0 ]`.