### PR TITLE
Enables testing on FreeBSD using environment variables

### DIFF
--- a/src/deno/BrowserFetcher.ts
+++ b/src/deno/BrowserFetcher.ts
@@ -194,7 +194,7 @@ export class BrowserFetcher {
       return;
     }
 
-    const platform = Deno.build.os;
+    const platform = Deno.env.get("PUPPETEER_PLATFORM") || Deno.build.os;
     if (platform === "darwin") this._platform = "mac";
     else if (platform === "linux") this._platform = "linux";
     else if (platform === "windows") {


### PR DESCRIPTION
  While on FreeBSD OS, using the environment variables makes tests to pass if we add a PUPPETEER_PLATFORM environment variable.
  Here is a sample:
```
export PUPPETEER_PRODUCT=chrome
export PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
export PUPPETEER_SKIP_DOWNLOAD=true
export PUPPETEER_PLATFORM=linux
deno test --unstable -A tests.ts
```