### PR TITLE
fix install on macOS

### DIFF
--- a/src/deno/BrowserFetcher.ts
+++ b/src/deno/BrowserFetcher.ts
@@ -505,6 +505,7 @@ async function installDMG(dmgPath: string, folderPath: string): Promise<void> {
   try {
     const proc = Deno.run({
       cmd: ["hdiutil", "attach", "-nobrowse", "-noautoopen", dmgPath],
+      stdout: "piped",
     });
     const stdout = new TextDecoder().decode(await proc.output());
     proc.close();


### PR DESCRIPTION
error: `Uncaught TypeError: stdout was not piped`
fixes: #28, #49