### PR TITLE
Fix: use node specifier for path module to fix the error: Error: JSHandle#uploadFile can only be used in Node-like environments.

### DIFF
--- a/vendor/puppeteer-core/puppeteer/common/ElementHandle.js
+++ b/vendor/puppeteer-core/puppeteer/common/ElementHandle.js
@@ -662,7 +662,7 @@ export class ElementHandle extends JSHandle {
     // Locate all files and confirm that they exist.
     let path;
     try {
-      path = await import("path");
+      path = await import("node:path");
     } catch (error) {
       if (error instanceof TypeError) {
         throw new Error(

--- a/vendor/puppeteer-core/puppeteer/common/IsolatedWorld.js
+++ b/vendor/puppeteer-core/puppeteer/common/IsolatedWorld.js
@@ -390,7 +390,7 @@ export class IsolatedWorld {
     if (path !== null) {
       let fs;
       try {
-        fs = (await import("fs")).promises;
+        fs = (await import("node:fs")).promises;
       } catch (error) {
         if (error instanceof TypeError) {
           throw new Error(


### PR DESCRIPTION
The `puppeteer-core` is depending on Node.js. We got error: JSHandle#uploadFile can only be used in Node-like environments when we want to upload file using puppeteer.

deno v1.30 provides `node:` specifier to use in this case.

We have an open issue regarded to this PR: #62 