### PR TITLE
fix: bump jszip

### DIFF
--- a/vendor/puppeteer-core/vendor/zip/mod.ts
+++ b/vendor/puppeteer-core/vendor/zip/mod.ts
@@ -1,4 +1,4 @@
-import _JSZip from "https://esm.sh/jszip@3.5.0";
+import _JSZip from "https://esm.sh/jszip@3.7.1";
 import { ensureDir } from "https://deno.land/std@0.93.0/fs/ensure_dir.ts";
 import { walk, WalkOptions } from "https://deno.land/std@0.93.0/fs/walk.ts";
 import { dirname, join, SEP } from "https://deno.land/std@0.93.0/path/mod.ts";


### PR DESCRIPTION
I'm getting errors while installing deno-puppeteer.

```
❯ deno run -A install.ts
error: invalid data
    at file:///Users/ricardo/code/deno-puppeteer/vendor/puppeteer-core/vendor/zip/mod.ts:1:20
```
Issue solved by bump jszip@3.5.0 

Uncertain if this is the root cause, but the URL https://esm.sh/jszip@3.5.0 is retuning binary output.
<img width="579" alt="image" src="https://github.com/lucacasonato/deno-puppeteer/assets/35773631/14212f75-9943-4950-bd5b-385606454896">

