### PR TITLE
Fix esm.sh/jszip breaking lock files

### DIFF
--- a/vendor/puppeteer-core/vendor/zip/mod.ts
+++ b/vendor/puppeteer-core/vendor/zip/mod.ts
@@ -1,4 +1,4 @@
-import _JSZip from "https://esm.sh/jszip@3.5.0";
+import _JSZip from "https://esm.sh/v128/jszip@3.5.0";
 import { ensureDir } from "https://deno.land/std@0.93.0/fs/ensure_dir.ts";
 import { walk, WalkOptions } from "https://deno.land/std@0.93.0/fs/walk.ts";
 import { dirname, join, SEP } from "https://deno.land/std@0.93.0/path/mod.ts";


### PR DESCRIPTION
Using esm.sh imports without the /v* path part after it causes esm.sh to return arbitrary import statements that changes over time.

This commit fixes the import path so that it forces esm.sh to return import statements according to the specific version instead of the latest one, which fixes lock files changing.